### PR TITLE
Fix broadcasting of operands

### DIFF
--- a/einsumt.py
+++ b/einsumt.py
@@ -123,8 +123,9 @@ def einsumt(*operands, **kwargs):
         for j in range(len(ops)):
             oj = ops[j]
             if cpos[j] >= 0:
-                jslice = cpos_slice[j] + (islice,)
-                oj = oj[jslice]
+                if oj.shape[cpos[j]] > 1:
+                    jslice = cpos_slice[j] + (islice,)
+                    oj = oj[jslice]
             args = args + (oj,)
         res += [pool.apply_async(np.einsum, args=args, kwds=kwargs)]
     res = [r.get() for r in res]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="einsumt",
-    version="0.9.2",
+    version="0.9.3",
     author="Marek Wojciechowski",
     author_email="mrkwjc@gmail.com",
     description="Multithreaded version of numpy.einsum function",

--- a/test_einsumt.py
+++ b/test_einsumt.py
@@ -123,6 +123,12 @@ class TestEinsumt(object):
         A2 = np.einsum('egmipq, egpqrs -> egmirs', u, A)
         k2 = np.einsum('egmirs, egnjrs -> eminj', A2, v)
         assert np.allclose(k1, k2)
+    
+    def test_broadcasting(self):
+        a = np.random.rand(3, 3, 1, 1)
+        b = np.random.rand(3, 3, 6, 100)
+        subs = 'ijrs,ijrs->rs'
+        assert np.allclose(np.einsum(subs, a, b), einsumt(subs, a, b))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes #1

# Solution
The slice `jslice` is only applied if the dimension of the chunk-component is greater than one.

## Tasks
- [x] Fix the mentioned Issue
- [x] Add an additional test `test_broadcasting()`
- [x] Successful run of the test suite
- [x] Raise the version tag to `0.9.3`

## Test the solution
```python
from einsumt import einsumt
import numpy as np

a = np.random.rand(3, 3, 1, 1)
b = np.random.rand(3, 3, 6, 100)

subs = 'ijrs,ijrs->rs'

assert np.allclose(np.einsum(subs, a, b), einsumt(subs, a, b))
```